### PR TITLE
Added allowHeaders = "*" to @CrossOrigin

### DIFF
--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/CommonCustomerApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/CommonCustomerApiController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class CommonCustomerApiController extends ApiControllerBase implements CommonCustomerApi {
 

--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/CommonDiscoveryApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/CommonDiscoveryApiController.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class CommonDiscoveryApiController extends ApiControllerBase implements CommonDiscoveryApi {
 

--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingAccountsApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingAccountsApiController.java
@@ -46,7 +46,7 @@ import java.util.UUID;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class BankingAccountsApiController extends ApiControllerBase implements BankingAccountsApi {
 

--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingDirectDebitsApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingDirectDebitsApiController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class BankingDirectDebitsApiController extends ApiControllerBase implements BankingDirectDebitsApi {
 

--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingPayeesApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingPayeesApiController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class BankingPayeesApiController extends ApiControllerBase implements BankingPayeesApi {
 

--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingProductsApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingProductsApiController.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class BankingProductsApiController extends ApiControllerBase implements BankingProductsApi {
 

--- a/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingScheduledPaymentsApiController.java
+++ b/data-holder/src/main/java/au/org/consumerdatastandards/holder/api/banking/BankingScheduledPaymentsApiController.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 
 @Validated
 @Controller
-@CrossOrigin
+@CrossOrigin(allowedHeaders = "*")
 @RequestMapping("${openapi.consumerDataStandards.base-path:/cds-au/v1}")
 public class BankingScheduledPaymentsApiController extends ApiControllerBase implements BankingScheduledPaymentsApi {
 


### PR DESCRIPTION
This is needed to allow a hosted web-based data recipient, such as DSB's Product Comparator Demo to access data-holder deployed locally or elsewhere.